### PR TITLE
Add .npmignore file to avoid bundling tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.DS_Store
+/node_modules
+/.lintcache
+/npm-debug.log
+test


### PR DESCRIPTION
Test files account for a 1.3MB bump in this package's size which
is avoidable by adding the directory to .npmignore