### PR TITLE
Exclude tests and development config files from npm bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+node_modules
+test
+.travis.yml
+.lint
+.lintcache
+.lintignore


### PR DESCRIPTION
This will reduce the size of the npm package and the amount of files installed