### PR TITLE
[#93] Upgraded package.json to avoid breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "es5-ext",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "ECMAScript extensions and shims",
 	"author": "Mariusz Nowak <medyk@medikoo.com> (http://www.medikoo.com/)",
 	"keywords": [
@@ -24,7 +24,7 @@
 	"repository": "medikoo/es5-ext",
 	"dependencies": {
 		"es6-iterator": "~2.0.3",
-		"es6-symbol": "~3.1.2",
+		"es6-symbol": "~3.1.3",
 		"next-tick": "~1.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
es6-symbols is released with version 3.1.3 and while the es5-ext mandates es6-symbol with version 3.1.2 causing a builds to break. A bug [#93] is created to track the changes. 