### PR TITLE
Remove excess `exports` statement

### DIFF
--- a/error/custom.js
+++ b/error/custom.js
@@ -5,7 +5,7 @@ var assign            = require("../object/assign")
   , isValue           = require("../object/is-value")
   , captureStackTrace = Error.captureStackTrace;
 
-exports = module.exports = function (message/*, code, ext*/) {
+module.exports = function (message/*, code, ext*/) {
 	var err = new Error(message), code = arguments[1], ext = arguments[2];
 	if (!isValue(ext)) {
 		if (isObject(code)) {
@@ -15,6 +15,6 @@ exports = module.exports = function (message/*, code, ext*/) {
 	}
 	if (isValue(ext)) assign(err, ext);
 	if (isValue(code)) err.code = code;
-	if (captureStackTrace) captureStackTrace(err, exports);
+	if (captureStackTrace) captureStackTrace(err, module.exports);
 	return err;
 };

--- a/object/serialize.js
+++ b/object/serialize.js
@@ -8,18 +8,20 @@ var toArray  = require("./to-array")
 var isArray = Array.isArray
   , stringify = JSON.stringify
   , objHasOwnProperty = Object.prototype.hasOwnProperty;
-var keyValueToString = function (value, key) { return stringify(key) + ":" + exports(value); };
+var keyValueToString = function (value, key) {
+  return stringify(key) + ":" + module.exports(value);
+};
 
 var sparseMap = function (arr) {
 	var i, length = arr.length, result = new Array(length);
 	for (i = 0; i < length; ++i) {
 		if (!objHasOwnProperty.call(arr, i)) continue;
-		result[i] = exports(arr[i]);
+		result[i] = module.exports(arr[i]);
 	}
 	return result;
 };
 
-module.exports = exports = function (obj) {
+module.exports = function (obj) {
 	if (!isValue(obj)) return String(obj);
 	switch (typeof obj) {
 		case "string":

--- a/object/unserialize.js
+++ b/object/unserialize.js
@@ -2,7 +2,7 @@
 
 var value = require("./valid-value");
 
-module.exports = exports = function (code) {
+module.exports = function (code) {
 	// eslint-disable-next-line no-new-func
 	return new Function("return " + value(code))();
 };


### PR DESCRIPTION
Hi, medikoo!

There are weird export statements in the following files:

- `errors/custom.js`
- `object/serialize.js`
- `object/unserialize.js`

They are weird in a sense that everywhere else export is done via just `module.exports`.

The issue here is that Node is unable to handle this type of export if the file is being executed in a `vm` context, see this issue: https://github.com/nodejs/help/issues/2094

I use [linaria](https://github.com/callstack/linaria) in my project (linaria basically parses and executes files and all of their dependencies inside `vm` contexts to determine the content of CSS files during build), so whenever there is an import from a file that somehow (in my case: through `memoizee`, which depends on `es5-ext`) imports `custom/error.js` (or other mentioned files), linaria fails.

See this example:

```js
// library.js
import memoizee from "memoizee/weak";

export const f = memoizee((/* ... */) => {
  /* ... */
});

export const colors = {
  RED: "red"
};

// Component.js
import styled from "linaria/react";
import { colors } from "./library.js";

const Component = styled.div`
  color: ${colors.RED};
`;
```

This will fail.
