### PR TITLE
Fix repository field in ext branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/medikoo/es5-ext/tree/ext"
+		"url": "https://github.com/medikoo/es5-ext#ext"
 	},
 	"dependencies": {
 		"type": "^2.0.0"


### PR DESCRIPTION
Problem: The repository field wasn't a valid Git repository.

Solution: Follow the "Git URLs" spec: https://docs.npmjs.com/files/package.json#git-urls-as-dependencies.