### PR TITLE
feat: bring up Array.shuffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ npm install ext
 ### Utilities
 
 - [`globalThis`](docs/global-this.md)
+- `Array`
+  - [`shuffle`](docs/array/shuffle.md)
 - `Function`
   - [`identity`](docs/function/identity.md)
 - `Math`

--- a/array/shuffle.js
+++ b/array/shuffle.js
@@ -1,12 +1,13 @@
 "use strict";
 
-var random = Math.random, isArray = Array.isArray;
+var random         = Math.random
+  , ensureIterable = require("type/iterable/ensure");
 
 module.exports = function (input) {
-	if (!isArray(input)) throw new TypeError("input must be an Array, got " + typeof input + "!");
+	ensureIterable(input);
 
 	// Make a clone of original array
-	var $array = input.slice(0);
+	var array = input.slice(0);
 
 	var sourceIndex = input.length;
 	var destinationIndex = 0;
@@ -17,8 +18,8 @@ module.exports = function (input) {
 	while (sourceIndex) {
 		// eslint-disable-next-line no-bitwise
 		var randomIndex = (sourceIndex * random()) | 0;
-		shuffled[destinationIndex++] = $array[randomIndex];
-		$array[randomIndex] = $array[--sourceIndex];
+		shuffled[destinationIndex++] = array[randomIndex];
+		array[randomIndex] = array[--sourceIndex];
 	}
 
 	return shuffled;

--- a/array/shuffle.js
+++ b/array/shuffle.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var random = Math.random, isArray = Array.isArray;
+
+module.exports = function (input) {
+	if (!isArray(input)) throw new TypeError("input must be an Array, got " + typeof input + "!");
+
+	// Make a clone of original array
+	var $array = input.slice(0);
+
+	var sourceIndex = input.length;
+	var destinationIndex = 0;
+
+	// Pre-assign the size of array
+	var shuffled = new Array(sourceIndex);
+
+	while (sourceIndex) {
+		// eslint-disable-next-line no-bitwise
+		var randomIndex = (sourceIndex * random()) | 0;
+		shuffled[destinationIndex++] = $array[randomIndex];
+		$array[randomIndex] = $array[--sourceIndex];
+	}
+
+	return shuffled;
+};

--- a/docs/array/shuffle.md
+++ b/docs/array/shuffle.md
@@ -1,0 +1,9 @@
+# `Array.shuffle` _(ext/array/shuffle)_
+
+A fast, side-effect-free, and O(n) array shuffle which doesn't mutate the source array.
+
+```javascript
+const shuffle = require("ext/array/shuffle");
+
+shuffle([1, 2, 3, 4, 5]);
+```

--- a/test/array/shuffle.js
+++ b/test/array/shuffle.js
@@ -9,26 +9,11 @@ describe("array/shuffle", function () {
 	// Adopt from lodash.shuffle
 	// https://github.com/lodash/lodash/blob/master/test/shuffle.js
 	it("should throw TypeError for non array input", function () {
-		try {
-			shuffle();
-		} catch (e) {
-			assert.strictEqual(e.name, "TypeError");
-			assert.strictEqual(e.message, "input must be an Array, got undefined!");
-		}
+		try { shuffle(); } catch (e) { assert.strictEqual(e.name, "TypeError"); }
 
-		try {
-			shuffle({});
-		} catch (e) {
-			assert.strictEqual(e.name, "TypeError");
-			assert.strictEqual(e.message, "input must be an Array, got object!");
-		}
+		try { shuffle({}); } catch (e) { assert.strictEqual(e.name, "TypeError"); }
 
-		try {
-			shuffle(1);
-		} catch (e) {
-			assert.strictEqual(e.name, "TypeError");
-			assert.strictEqual(e.message, "input must be an Array, got number!");
-		}
+		try { shuffle(1); } catch (e) { assert.strictEqual(e.name, "TypeError"); }
 	});
 
 	it("should return a new array", function () { assert.notStrictEqual(shuffle(array), array); });

--- a/test/array/shuffle.js
+++ b/test/array/shuffle.js
@@ -1,0 +1,66 @@
+"use strict";
+
+var assert  = require("chai").assert
+  , shuffle = require("../../array/shuffle");
+
+describe("array/shuffle", function () {
+	var array = [1, 2, 3];
+
+	// Adopt from lodash.shuffle
+	// https://github.com/lodash/lodash/blob/master/test/shuffle.js
+	it("should throw TypeError for non array input", function () {
+		try {
+			shuffle();
+		} catch (e) {
+			assert.strictEqual(e.name, "TypeError");
+			assert.strictEqual(e.message, "input must be an Array, got undefined!");
+		}
+
+		try {
+			shuffle({});
+		} catch (e) {
+			assert.strictEqual(e.name, "TypeError");
+			assert.strictEqual(e.message, "input must be an Array, got object!");
+		}
+
+		try {
+			shuffle(1);
+		} catch (e) {
+			assert.strictEqual(e.name, "TypeError");
+			assert.strictEqual(e.message, "input must be an Array, got number!");
+		}
+	});
+
+	it("should return a new array", function () { assert.notStrictEqual(shuffle(array), array); });
+
+	it("should contain the same elements after a collection is shuffled", function () {
+		assert.deepStrictEqual(shuffle(array).sort(), array);
+	});
+
+	// Adopt from fast-shuffle
+	// https://github.com/philihp/fast-shuffle/blob/master/src/__tests__/index.test.js
+	it("does not mutate the source", function () {
+		var d1 = ["A", "B", "C", "D", "E", "F", "G", "H"];
+		shuffle(d1);
+
+		assert.deepStrictEqual(d1, ["A", "B", "C", "D", "E", "F", "G", "H"]);
+	});
+
+	it("does a shallow clone", function () {
+		var d1 = [
+			{ name: "Alice", money: 10 }, { name: "Betty", money: 20 }, { name: "Cindy", money: 15 }
+		];
+		var d2 = shuffle(d1);
+
+		assert.include(d2, d1[0]);
+		assert.include(d2, d1[1]);
+		assert.include(d2, d1[2]);
+	});
+
+	it("works with massive noise", function () {
+		var d1 = new Array(500).fill().map(function (_, i) { return i; });
+		var d2 = shuffle(d1);
+
+		assert.deepStrictEqual(d1.sort(), d2.sort());
+	});
+});


### PR DESCRIPTION
The PR closes #100, bringing up a side-effect-free, and O(n) array shuffle function.

The unit test is not finished since `tad` is not powerful enough to write a unit test for `shuffle` (Help is wanted).

P.S. I want to adopt the unit test from https://github.com/philihp/fast-shuffle/blob/master/src/__tests__/index.test.js