### PR TITLE
Add workaround to postinstall to prevent npx error

### DIFF
--- a/_postinstall.js
+++ b/_postinstall.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 // Broadcasts "Call for peace" message when package is installed in Russia, otherwise no-op
 
 "use strict";

--- a/_postinstall.js
+++ b/_postinstall.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Broadcasts "Call for peace" message when package is installed in Russia, otherwise no-op
 
 "use strict";

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"coverage": "nyc npm test",
 		"lint": "eslint --ignore-path=.gitignore .",
 		"lint:updated": "pipe-git-updated --base=main --ext=js -- eslint --ignore-pattern '!*'",
-		"postinstall": "node ./_postinstall.js",
+		"postinstall": "node -e \"try{require('./_postinstall')}catch(e){}\"",
 		"prettier-check": "prettier -c --ignore-path .gitignore \"**/*.{css,html,js,json,md,yaml,yml}\"",
 		"prettier-check:updated": "pipe-git-updated --base=main --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier -c",
 		"prettify": "prettier --write --ignore-path .gitignore \"**/*.{css,html,js,json,md,yaml,yml}\"",


### PR DESCRIPTION
This workaround try to fix this issue:

Fixes https://github.com/medikoo/es5-ext/issues/109

And its based on the same problem in core-js lib:

https://github.com/zloirock/core-js/issues/551

